### PR TITLE
Use Volk to pack/unpack IQ samples

### DIFF
--- a/grc/difi_sink_cpp.block.yml
+++ b/grc/difi_sink_cpp.block.yml
@@ -8,10 +8,9 @@ label: DIFI Sink
 category: '[DIFI]'
 templates:
   imports: import difi
-  make: difi.difi_sink_cpp_${type.fcn}(${reference_time_full}, ${reference_time_frac}, ${ip_addr}, ${port}, ${protocol}, bool(${mode}),
+  make: difi.difi_sink_cpp_${bit_depth.fcn}_${type.fcn}(${reference_time_full}, ${reference_time_frac}, ${ip_addr}, ${port}, ${protocol}, bool(${mode}),
                                                        ${data_size}, ${stream_id}, ${sample_rate},
-                                                       ${context_packet_send_count}, int(${context_pack_size}), ${rf_gain_dB}, ${if_gain_dB}, int(${bit_depth}), int(${scaling}), ${gain},
-                                                       ${offset}, ${max_iq}, ${min_iq})
+                                                       ${context_packet_send_count}, int(${context_pack_size}), ${rf_gain_dB}, ${if_gain_dB})
 
 parameters:
 - id: type
@@ -29,6 +28,8 @@ parameters:
   label: Bit Depth
   dtype: enum
   options: ['8', '16']
+  option_attributes:
+      fcn: [sc8, sc16]
   default: '8'
 - id: ip_addr
   label: Forwarding IP Address
@@ -86,37 +87,6 @@ parameters:
   dtype: real
   default: -1.3
   hide: ${ ('all' if mode == 'True' else 'none') }  
-- id: scaling
-  category: Scaling
-  label: Scaling Mode
-  dtype: enum
-  options: ['0', '1', '2']
-  option_labels: ['None', 'Manual', 'Min-Max']
-  default: '2'
-- id: gain
-  category: Scaling
-  label: Gain
-  dtype: real
-  default: 1.0
-  hide: ${ ('none' if scaling == '1' else 'all') }
-- id: offset
-  category: Scaling
-  label: Complex Offset
-  dtype: complex
-  default: 0
-  hide: ${ ('none' if scaling == '1' else 'all') }
-- id: max_iq
-  category: Scaling
-  label: Max IQ Value
-  dtype: real
-  default: 1.0
-  hide: ${ ('none' if scaling == '2' else 'all') }
-- id: min_iq
-  category: Scaling
-  label: Min IQ Value
-  dtype: real
-  default: -1.0
-  hide: ${ ('none' if scaling == '2' else 'all') }
 inputs:
 - label: in
   domain: stream
@@ -167,20 +137,5 @@ documentation: |-
 
      bit_depth:
      The bit depth
-
-     scaling:
-     The scaling mode
-
-     gain:
-     In manual scaling mode, gain applied to signal
-
-     offset:
-     In manual scaling mode, complex offset added to signal
-
-     max_iq:
-     In Min-Max scaling mode, expectd maximum value of I or Q ie. Max(Max(I),Max(Q))
-
-     min_iq:
-     In Min-Max scaling mode, expectd minimum value of I or Q ie. Min(Min(I),Min(Q))
 
 file_format: 1

--- a/grc/difi_source_cpp.block.yml
+++ b/grc/difi_source_cpp.block.yml
@@ -8,7 +8,7 @@ label: DIFI Source
 category: '[DIFI]'
 templates:
   imports: import difi
-  make: difi.difi_source_cpp_${type.fcn}(${ip_addr}, ${port}, ${protocol}, ${stream_num}, int(${bit_depth}), int(${context_behavior}))
+  make: difi.difi_source_cpp_${bit_depth.fcn}_${type.fcn}(${ip_addr}, ${port}, ${protocol}, ${stream_num}, int(${context_behavior}))
 
 parameters:
 - id: type
@@ -22,6 +22,8 @@ parameters:
   label: Bit Depth
   dtype: enum
   options: ['8', '16']
+  option_attributes:
+      fcn: [sc8, sc16]
   default: '8'
 - id: ip_addr
   label: Source IP Address

--- a/include/difi/difi_sink_cpp.h
+++ b/include/difi/difi_sink_cpp.h
@@ -9,25 +9,26 @@
 
 #include <difi/api.h>
 #include <gnuradio/sync_block.h>
+#include <cstdint>
 
 namespace gr {
   namespace difi {
   
-    template <class T>
+    template <class T, class S>
     class DIFI_API difi_sink_cpp : virtual public gr::sync_block
     {
      public:
-      typedef std::shared_ptr<difi_sink_cpp<T>> sptr;
+      typedef std::shared_ptr<difi_sink_cpp<T, S>> sptr;
       
       static sptr make(u_int32_t reference_time_full, u_int64_t reference_time_frac, std::string ip_addr, uint32_t port, uint8_t socket_type, bool mode, uint32_t samples_per_packet, 
-                      int stream_number, u_int64_t samp_rate, int context_interval, int context_pack_size, float rf_gain_dB, float if_gain_dB, int bit_depth,
-                      int scaling, float gain, gr_complex offset, float max_iq, float min_iq);
+                      int stream_number, u_int64_t samp_rate, int context_interval, int context_pack_size, float rf_gain_dB, float if_gain_dB);
     };
-    typedef difi_sink_cpp<gr_complex> difi_sink_cpp_fc32;
-    typedef difi_sink_cpp<std::complex<char>> difi_sink_cpp_sc8;
+    typedef difi_sink_cpp<gr_complex, std::complex<int16_t>> difi_sink_cpp_sc16_fc32;
+    typedef difi_sink_cpp<gr_complex, std::complex<int8_t>> difi_sink_cpp_sc8_fc32;
+    typedef difi_sink_cpp<std::complex<int8_t>, std::complex<int16_t>> difi_sink_cpp_sc16_sc8;
+    typedef difi_sink_cpp<std::complex<int8_t>, std::complex<int8_t>> difi_sink_cpp_sc8_sc8;
 
   } // namespace difi
 } // namespace gr
 
 #endif /* INCLUDED_DIFI_SINK_CPP_H */
-

--- a/include/difi/difi_source_cpp.h
+++ b/include/difi/difi_source_cpp.h
@@ -9,21 +9,24 @@
 
 #include <difi/api.h>
 #include <gnuradio/sync_block.h>
+#include <cstdint>
 
 namespace gr {
   namespace difi {
 
-    template <class T>
+    template <class T, class S>
     class DIFI_API difi_source_cpp : virtual public gr::sync_block
     {
      public:
-      typedef std::shared_ptr<difi_source_cpp<T>> sptr;
+      typedef std::shared_ptr<difi_source_cpp<T, S>> sptr;
 
-      static sptr make(std::string ip_addr, uint32_t port, uint8_t socket_type, int stream_number, int bit_depth, int context_pkt_behavior);
+      static sptr make(std::string ip_addr, uint32_t port, uint8_t socket_type, int stream_number, int context_pkt_behavior);
 
     };
-    typedef difi_source_cpp<gr_complex> difi_source_cpp_fc32;
-    typedef difi_source_cpp<std::complex<char>> difi_source_cpp_sc8;
+    typedef difi_source_cpp<gr_complex, std::complex<int16_t>> difi_source_cpp_sc16_fc32;
+    typedef difi_source_cpp<gr_complex, std::complex<int8_t>> difi_source_cpp_sc8_fc32;
+    typedef difi_source_cpp<std::complex<int8_t>, std::complex<int16_t>> difi_source_cpp_sc16_sc8;
+    typedef difi_source_cpp<std::complex<int8_t>, std::complex<int8_t>> difi_source_cpp_sc8_sc8;
 
   } // namespace difi
 } // namespace gr

--- a/lib/difi_sink_cpp_impl.h
+++ b/lib/difi_sink_cpp_impl.h
@@ -19,8 +19,8 @@ namespace gr {
   class tcp_client;
   class udp_socket;
 
-    template <class T>
-    class difi_sink_cpp_impl : public difi_sink_cpp<T>
+    template <class T, class S>
+    class difi_sink_cpp_impl : public difi_sink_cpp<T, S>
     {
      private:
         void pack_u64(unsigned char * start, u_int64_t val)
@@ -45,9 +45,10 @@ namespace gr {
           memcpy(start, &val, sizeof(val));
         }
 
+        static void pack_samples(S* output_vector, const T* input_vector, size_t num_samples);
+
         void process_tags(int noutput_items);
-        void pack_T(T val);
-        std::vector<int8_t> pack_data();
+        void pack_data();
         void send_context();
         std::tuple<u_int32_t, u_int64_t> add_frac_full();
 
@@ -66,6 +67,7 @@ namespace gr {
         std::vector<int8_t> d_raw;
         std::vector<u_int8_t> d_context_raw;
         std::vector<int8_t> d_out_buf;
+        std::vector<int8_t> d_to_send;
         double d_time_adj;
         u_int64_t d_pcks_since_last_reference;
         int d_current_buff_idx;
@@ -78,11 +80,6 @@ namespace gr {
         u_int32_t d_context_static_bits;
         u_int32_t d_unpack_idx_size;
         u_int32_t d_samples_per_packet;
-        int d_scaling_mode;
-        float d_gain;
-        gr_complex d_offset;
-        float d_max_iq;
-        float d_min_iq;
 
         tcp_client* p_tcpsocket;
         udp_socket* p_udpsocket;
@@ -90,7 +87,7 @@ namespace gr {
      public:
       difi_sink_cpp_impl(u_int32_t reference_time_full, u_int64_t reference_time_frac, std::string ip_addr, uint32_t port, uint8_t socket_type, bool mode,
                         uint32_t samples_per_packet, int stream_number, u_int64_t samp_rate,
-                        int context_interval, int context_pack_size, float rf_gain, float if_gain, int bit_depth, int scaling, float gain, gr_complex offset, float max_iq, float min_iq);
+                        int context_interval, int context_pack_size, float rf_gain, float if_gain);
       ~difi_sink_cpp_impl();
 
       // Where all the action really happens
@@ -105,4 +102,3 @@ namespace gr {
 } // namespace gr
 
 #endif /* INCLUDED_DIFI_SINK_CPP_IMPL_H */
-

--- a/python/bindings/difi_sink_cpp_python.cc
+++ b/python/bindings/difi_sink_cpp_python.cc
@@ -15,11 +15,11 @@ namespace py = pybind11;
 // pydoc.h is automatically generated in the build directory
 #include <difi_sink_cpp_pydoc.h>
 
-template <typename T>
+template <typename T, typename S>
 void bind_difi_sink_cpp_template(py::module& m, const char* classname)
 {
 
-    using difi_sink_cpp    = ::gr::difi::difi_sink_cpp<T>;
+    using difi_sink_cpp    = ::gr::difi::difi_sink_cpp<T, S>;
 
 
     py::class_<difi_sink_cpp, gr::sync_block, gr::block, gr::basic_block,
@@ -39,12 +39,6 @@ void bind_difi_sink_cpp_template(py::module& m, const char* classname)
            py::arg("context_pack_size"),
            py::arg("rf_gain_dB"),
            py::arg("if_gain_dB"),
-           py::arg("bit_depth"),
-           py::arg("scaling"),
-           py::arg("gain"),
-           py::arg("offset"),
-           py::arg("max_iq"),
-           py::arg("min_iq"),
            D(difi_sink_cpp,make)
         );
 
@@ -52,14 +46,8 @@ void bind_difi_sink_cpp_template(py::module& m, const char* classname)
 
 void bind_difi_sink_cpp(py::module& m)
 {
-    bind_difi_sink_cpp_template<gr_complex>(m, "difi_sink_cpp_fc32");
-    bind_difi_sink_cpp_template<std::complex<char>>(m, "difi_sink_cpp_sc8");
+    bind_difi_sink_cpp_template<gr_complex, std::complex<int16_t>>(m, "difi_sink_cpp_sc16_fc32");
+    bind_difi_sink_cpp_template<gr_complex, std::complex<int8_t>>(m, "difi_sink_cpp_sc8_fc32");
+    bind_difi_sink_cpp_template<std::complex<int8_t>, std::complex<int16_t>>(m, "difi_sink_cpp_sc16_sc8");
+    bind_difi_sink_cpp_template<std::complex<int8_t>, std::complex<int8_t>>(m, "difi_sink_cpp_sc8_sc8");
 }
-
-
-
-
-
-
-
-

--- a/python/bindings/difi_source_cpp_python.cc
+++ b/python/bindings/difi_source_cpp_python.cc
@@ -15,11 +15,11 @@ namespace py = pybind11;
 #include <difi_source_cpp_pydoc.h>
 
 
-template <typename T>
+template <typename T, typename S>
 void bind_difi_source_cpp_template(py::module& m, const char* classname)
 {
 
-    using difi_source_cpp    = ::gr::difi::difi_source_cpp<T>;
+    using difi_source_cpp    = ::gr::difi::difi_source_cpp<T, S>;
 
 
     py::class_<difi_source_cpp, gr::sync_block, gr::block, gr::basic_block,
@@ -30,7 +30,6 @@ void bind_difi_source_cpp_template(py::module& m, const char* classname)
            py::arg("port"),
            py::arg("protocol"),
            py::arg("stream_number"),
-           py::arg("bit_depth"),
            py::arg("context_pkt_behavior"),
            D(difi_source_cpp,make)
         );
@@ -38,14 +37,8 @@ void bind_difi_source_cpp_template(py::module& m, const char* classname)
 
 void bind_difi_source_cpp(py::module& m)
 {
-    bind_difi_source_cpp_template<gr_complex>(m, "difi_source_cpp_fc32");
-    bind_difi_source_cpp_template<std::complex<char>>(m, "difi_source_cpp_sc8");
+    bind_difi_source_cpp_template<gr_complex, std::complex<int16_t>>(m, "difi_source_cpp_sc16_fc32");
+    bind_difi_source_cpp_template<gr_complex, std::complex<int8_t>>(m, "difi_source_cpp_sc8_fc32");
+    bind_difi_source_cpp_template<std::complex<int8_t>, std::complex<int16_t>>(m, "difi_source_cpp_sc16_sc8");
+    bind_difi_source_cpp_template<std::complex<int8_t>, std::complex<int8_t>>(m, "difi_source_cpp_sc8_sc8");
 }
-
-
-
-
-
-
-
-


### PR DESCRIPTION
This modifies the DIFI Sink and Source so that they use Volk to pack/unpack the IQ samples, greatly improving the performance (CPU usage down by more than a factor of 2 in some benchmarks).

A new template parameter S is added to the sink and source blocks to indicate if DIFI packets use std::complex<int8_t> or std::complex<int16_t>. Therefore, 4 variants of each sink/source block are generated, allowing us to choose the appropriate Volk kernel for the IQ sample conversion at compile time.

The scaling in the DIFI Sink has been simplified. Instead of supporting different scaling modes, the input is converted from the range [-1.0, 1.0] to [-127, 127] or [-32767, 32767]. If custom scaling is required, it can be accomplished with Add Const and Multiply Const blocks outside of the DIFI Sink.

Additionally, instead of allocating a std::vec to contain the DIFI packet in the DIFI Sink every time that a packet is sent, the std::vec is allocated in the class constructor and re-used every time.